### PR TITLE
Add async model initialization and sampling in Telegram bot

### DIFF
--- a/molecule.py
+++ b/molecule.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+import asyncio
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -17,6 +17,31 @@ load_dotenv()
 TOKEN = os.getenv("TELEGRAM_TOKEN")
 
 
+MODEL_READY = asyncio.Event()
+
+
+async def ensure_model() -> None:
+    model_path = Path("names/model.pt")
+    if model_path.exists():
+        MODEL_READY.set()
+        return
+    proc = await asyncio.create_subprocess_exec(
+        "python",
+        "le.py",
+        "-i",
+        "blood/lines01.txt",
+        "-o",
+        "names",
+        "--max-steps",
+        "200",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    if proc.returncode == 0 and model_path.exists():
+        MODEL_READY.set()
+
+
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(
         "Hi! Send me a message and I'll ask LE to respond."
@@ -24,54 +49,41 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await MODEL_READY.wait()
     try:
-        model_path = Path("names/model.pt")
-        if not model_path.exists():
-            subprocess.run(
-                [
-                    "python",
-                    "le.py",
-                    "-i",
-                    "blood/lines01.txt",
-                    "-o",
-                    "names",
-                    "--max-steps",
-                    "200",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=600,
+        proc = await asyncio.create_subprocess_exec(
+            "python",
+            "le.py",
+            "-i",
+            "blood/lines01.txt",
+            "-o",
+            "names",
+            "--sample-only",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            reply = f"Error: {stderr.decode().strip()}"
+        else:
+            lines = [
+                line for line in stdout.decode().splitlines()
+                if line.strip()
+            ]
+            reply = (
+                "\n".join(lines[-10:]) if lines else "No output from LE."
             )
-        result = subprocess.run(
-            [
-                "python",
-                "le.py",
-                "-i",
-                "blood/lines01.txt",
-                "-o",
-                "names",
-                "--sample-only",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=60,
-        )
-        lines = [
-            line for line in result.stdout.splitlines()
-            if line.strip()
-        ]
-        reply = (
-            "\n".join(lines[-10:]) if lines else "No output from LE."
-        )
     except Exception as exc:
         reply = f"Error: {exc}"
     await update.message.reply_text(reply)
 
 
+async def post_init(app):
+    app.create_task(ensure_model())
+
+
 def main() -> None:
-    app = ApplicationBuilder().token(TOKEN).build()
+    app = ApplicationBuilder().token(TOKEN).post_init(post_init).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, respond)


### PR DESCRIPTION
## Summary
- Add async `ensure_model` to build model at startup and signal readiness
- Replace blocking subprocess usage with `asyncio.create_subprocess_exec`
- Ensure `respond` waits on model readiness event before sampling

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a01e8bb883299c6db897d4cdd1f7