### PR TITLE
Handle CUDA availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-LÉ
+# LÉ
+
+LE is a hackable character-level language model trainer.
+
+Training and sampling run on CPU by default. A GPU is optional—if CUDA is available the script will use it, otherwise it automatically falls back to CPU, so no GPU is required.

--- a/le.py
+++ b/le.py
@@ -660,8 +660,14 @@ if __name__ == '__main__':
     print(vars(args))
 
     # system inits
+    # ensure we fall back to CPU if CUDA is unavailable
+    if args.device.startswith('cuda') and not torch.cuda.is_available():
+        print("CUDA is not available, falling back to CPU.")
+        args.device = 'cpu'
+
     torch.manual_seed(args.seed)
-    torch.cuda.manual_seed_all(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
     os.makedirs(args.work_dir, exist_ok=True)
     writer = SummaryWriter(log_dir=args.work_dir)
 
@@ -725,7 +731,7 @@ if __name__ == '__main__':
         optimizer.step()
 
         # wait for all CUDA work on the GPU to finish then calculate iteration time taken
-        if args.device.startswith('cuda'):
+        if args.device.startswith('cuda') and torch.cuda.is_available():
             torch.cuda.synchronize()
         t1 = time.time()
 


### PR DESCRIPTION
## Summary
- add CPU fallback when CUDA is unavailable
- guard CUDA seed/sync calls with `torch.cuda.is_available`
- clarify in docs that GPU is optional

## Testing
- `pytest -q`
- `flake8 .` *(fails: E501 line too long, F401 imported but unused, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4ba041c7c83298d0786ba2a774447