### PR TITLE
Make model path configurable via work dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LÉ
 
-On startup the bot checks for an existing model in `names/model.pt`. If the
-file is missing, training is launched immediately in the background using
+On startup the bot checks for an existing model in `<work-dir>/model.pt`. The
+working directory can be configured with the `LE_WORK_DIR` environment variable
+or by passing `--work-dir` when invoking `le.py`. If the file is missing,
+training is launched immediately in the background using
 `asyncio.create_task`, allowing the bot to stay responsive while the model is
 built.

--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
+import os
 from pathlib import Path
 
 from memory import Memory
 
-MODEL_PATH = Path("names/model.pt")
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
+MODEL_PATH = WORK_DIR / "model.pt"
 
 # Global memory instance
 memory = Memory()

--- a/molecule.py
+++ b/molecule.py
@@ -21,6 +21,7 @@ from inhale_exhale import inhale, exhale
 load_dotenv()
 
 TOKEN = os.getenv("TELEGRAM_TOKEN")
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
 TRAINING_TASK: asyncio.Task | None = None
 
 
@@ -32,7 +33,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     question = update.message.text
-    model_path = Path("names/model.pt")
+    model_path = WORK_DIR / "model.pt"
     if not model_path.exists():
         if TRAINING_TASK and not TRAINING_TASK.done():
             await update.message.reply_text(
@@ -52,8 +53,8 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 "le.py",
                 "-i",
                 str(dataset_path),
-                "-o",
-                "names",
+                "--work-dir",
+                str(WORK_DIR),
                 "--sample-only",
                 "--num-samples",
                 "1",
@@ -88,8 +89,8 @@ async def run_training(
             "le.py",
             "-i",
             str(dataset_path),
-            "-o",
-            "names",
+            "--work-dir",
+            str(WORK_DIR),
             "--max-steps",
             "200",
             stdout=asyncio.subprocess.PIPE,

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -18,6 +18,7 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     names_dir = tmp_path / "names"
     names_dir.mkdir()
     (names_dir / "model.pt").write_text("dummy")
+    molecule.WORK_DIR = names_dir
     monkeypatch.chdir(tmp_path)
 
     dataset_file = tmp_path / "dataset.txt"
@@ -57,4 +58,5 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     assert replies == ["sample"]
     assert "--num-samples" in captured['args'] and "1" in captured['args']
     assert "--quiet" in captured['args']
+    assert "--work-dir" in captured['args'] and str(names_dir) in captured['args']
     assert "\n" not in replies[0]


### PR DESCRIPTION
## Summary
- read working directory from `LE_WORK_DIR`
- pass `--work-dir` to `le.py` for sampling and training
- adjust tests and docs to use configurable model path

## Testing
- `ruff check molecule.py inhale_exhale.py tests/test_respond_single_line.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ce3195b883299f59a8336b6a066a