### PR TITLE
Handle sampling timeouts and warm up model

### DIFF
--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -1,3 +1,4 @@
+import subprocess
 import types
 
 import pytest
@@ -60,3 +61,40 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     assert "--quiet" in captured['args']
     assert "--work-dir" in captured['args'] and str(names_dir) in captured['args']
     assert "\n" not in replies[0]
+
+
+@pytest.mark.asyncio
+async def test_respond_handles_timeout(monkeypatch, tmp_path):
+    names_dir = tmp_path / "names"
+    names_dir.mkdir()
+    (names_dir / "model.pt").write_text("dummy")
+    molecule.WORK_DIR = names_dir
+    dataset_file = tmp_path / "dataset.txt"
+    dataset_file.write_text("hello\n")
+    monkeypatch.setattr(molecule, "build_dataset", lambda: dataset_file)
+    monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
+
+    async def dummy_exhale(chat_id, context):
+        return None
+
+    monkeypatch.setattr(molecule, "exhale", dummy_exhale)
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=1)
+
+    monkeypatch.setattr(molecule.subprocess, "run", fake_run)
+
+    replies = []
+
+    class DummyMessage:
+        text = "hi"
+
+        async def reply_text(self, text):
+            replies.append(text)
+
+    update = types.SimpleNamespace(
+        message=DummyMessage(), effective_chat=types.SimpleNamespace(id=1)
+    )
+    await molecule.respond(update, None)
+
+    assert replies == ["Sampling timed out."]


### PR DESCRIPTION
## Summary
- make sampling timeout configurable and increase default
- warm up model at startup to speed `--sample-only`
- handle subprocess timeouts with user-friendly message
- test timeout handling in `respond`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d04d029883299bd5cfa58fb2a84b