### PR TITLE
Auto-start training when model missing

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -17,10 +17,11 @@ def _startup_training_check() -> None:
     if not MODEL_PATH.exists():
         import molecule  # Local import to avoid circular dependency
 
-        logging.info("Model file missing; starting initial training")
-        molecule.TRAINING_TASK = asyncio.create_task(
-            molecule.run_training(None, None)
-        )
+        if molecule.TRAINING_TASK is None or molecule.TRAINING_TASK.done():
+            logging.info("Model file missing; starting initial training")
+            molecule.TRAINING_TASK = asyncio.create_task(
+                molecule.run_training(None, None)
+            )
 
 
 asyncio.get_event_loop().call_soon(_startup_training_check)

--- a/molecule.py
+++ b/molecule.py
@@ -66,17 +66,15 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    global TRAINING_TASK
     question = update.message.text
     model_path = WORK_DIR / "model.pt"
     if not model_path.exists():
-        if TRAINING_TASK and not TRAINING_TASK.done():
-            await update.message.reply_text(
-                "Training in progress. Please wait."
-            )
-        else:
-            await update.message.reply_text(
-                "Model not trained yet. Send /train to start training."
-            )
+        if TRAINING_TASK is None or TRAINING_TASK.done():
+            TRAINING_TASK = asyncio.create_task(run_training(None, None))
+        await update.message.reply_text(
+            "Модель запускается, попробуйте позже"
+        )
         return
     dataset_path = build_dataset()
     try:


### PR DESCRIPTION
## Summary
- Automatically launch background training when the model file is missing and reply with a neutral message instead of suggesting `/train`
- Align startup training check and runtime response logic to prevent duplicate training tasks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d53e43ac8329887ebce06dbdf45f