### PR TITLE
Limit training dataset size

### DIFF
--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -1,0 +1,15 @@
+import molecule
+
+
+def test_build_dataset_enforces_limit(tmp_path, monkeypatch):
+    blood_dir = tmp_path / "blood"
+    blood_dir.mkdir()
+    chunk = "a" * (molecule.TRAINING_LIMIT_BYTES // 2)
+    (blood_dir / "f1.txt").write_text(chunk)
+    (blood_dir / "f2.txt").write_text(chunk)
+    monkeypatch.chdir(tmp_path)
+    dataset_path = molecule.build_dataset()
+    try:
+        assert dataset_path.stat().st_size == molecule.TRAINING_LIMIT_BYTES
+    finally:
+        dataset_path.unlink()

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -59,7 +59,8 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     assert replies == ["sample"]
     assert "--num-samples" in captured['args'] and "1" in captured['args']
     assert "--quiet" in captured['args']
-    assert "--work-dir" in captured['args'] and str(names_dir) in captured['args']
+    assert "--work-dir" in captured["args"]
+    assert str(names_dir) in captured["args"]
     assert "\n" not in replies[0]
 
 


### PR DESCRIPTION
## Summary
- stop dataset generation after 20KB and expose limit as TRAINING_LIMIT_BYTES
- add coverage test for dataset size limit
- tidy up respond test assertions

## Testing
- `flake8 molecule.py tests/test_build_dataset.py tests/test_auto_training.py tests/test_respond_single_line.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d73127a4832986dbf565779ee50e