### PR TITLE
Rename default work dir to le_data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,13 @@ charlotte
 Let's point the script at it:
 
 ```bash
-$ python le.py -i blood/lines01.txt -o names
+$ python le.py -i blood/lines01.txt -o le_data
 ```
 
-Training progress and logs and model will all be saved to the working directory `names`. The default model is a super tiny 200K param transformer; Many more training configurations are available - see the argparse and read the code. Training does not require any special hardware, it runs on my Macbook Air and will run on anything else, but if you have a GPU then training will fly faster. As training progresses the script will print some samples throughout. However, if you'd like to sample manually, you can use the `--sample-only` flag, e.g. in a separate terminal do:
+Training progress and logs and model will all be saved to the working directory `le_data`. The default model is a super tiny 200K param transformer; Many more training configurations are available - see the argparse and read the code. Training does not require any special hardware, it runs on my Macbook Air and will run on anything else, but if you have a GPU then training will fly faster. As training progresses the script will print some samples throughout. However, if you'd like to sample manually, you can use the `--sample-only` flag, e.g. in a separate terminal do:
 
 ```bash
-$ python le.py -i blood/lines01.txt -o names --sample-only
+$ python le.py -i blood/lines01.txt -o le_data --sample-only
 ```
 
 This will load the best model so far and print more samples on demand. Here are some unique baby names that get eventually generated from current default settings (test logprob of ~1.92, though much lower logprobs are achievable with some hyperparameter tuning):

--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from memory import Memory
 
-WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "le_data"))
 MODEL_PATH = WORK_DIR / "model.pt"
 
 # Global memory instance

--- a/molecule.py
+++ b/molecule.py
@@ -21,7 +21,7 @@ from inhale_exhale import inhale, exhale
 load_dotenv()
 
 TOKEN = os.getenv("TELEGRAM_TOKEN")
-WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "le_data"))
 SAMPLE_TIMEOUT = int(os.getenv("LE_SAMPLE_TIMEOUT", "120"))
 TRAINING_TASK: asyncio.Task | None = None
 TRAINING_LIMIT_BYTES = 20 * 1024

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -16,10 +16,10 @@ molecule.TRAINING_TASK = None
 
 @pytest.mark.asyncio
 async def test_respond_produces_one_line(monkeypatch, tmp_path):
-    names_dir = tmp_path / "names"
-    names_dir.mkdir()
-    (names_dir / "model.pt").write_text("dummy")
-    molecule.WORK_DIR = names_dir
+    work_dir = tmp_path / "le_data"
+    work_dir.mkdir()
+    (work_dir / "model.pt").write_text("dummy")
+    molecule.WORK_DIR = work_dir
     monkeypatch.chdir(tmp_path)
 
     dataset_file = tmp_path / "dataset.txt"
@@ -60,16 +60,16 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     assert "--num-samples" in captured['args'] and "1" in captured['args']
     assert "--quiet" in captured['args']
     assert "--work-dir" in captured["args"]
-    assert str(names_dir) in captured["args"]
+    assert str(work_dir) in captured["args"]
     assert "\n" not in replies[0]
 
 
 @pytest.mark.asyncio
 async def test_respond_handles_timeout(monkeypatch, tmp_path):
-    names_dir = tmp_path / "names"
-    names_dir.mkdir()
-    (names_dir / "model.pt").write_text("dummy")
-    molecule.WORK_DIR = names_dir
+    work_dir = tmp_path / "le_data"
+    work_dir.mkdir()
+    (work_dir / "model.pt").write_text("dummy")
+    molecule.WORK_DIR = work_dir
     dataset_file = tmp_path / "dataset.txt"
     dataset_file.write_text("hello\n")
     monkeypatch.setattr(molecule, "build_dataset", lambda: dataset_file)


### PR DESCRIPTION
## Summary
- Update default WORK_DIR to `le_data` in core modules
- Adjust tests and documentation to use new work directory name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d97a03488329a40e6a4459855a33