### PR TITLE
Limit dataset size to configurable byte threshold

### DIFF
--- a/molecule.py
+++ b/molecule.py
@@ -182,18 +182,16 @@ def build_dataset() -> Path:
     ) as tmp:
         total = 0
         for txt_file in Path("blood").glob("*.txt"):
-            data = txt_file.read_text(encoding="utf-8") + "\n"
-            encoded = data.encode("utf-8")
-            if total + len(encoded) > TRAINING_LIMIT_BYTES:
-                remaining = TRAINING_LIMIT_BYTES - total
-                if remaining > 0:
-                    partial = encoded[:remaining].decode(
-                        "utf-8", errors="ignore"
-                    )
-                    tmp.write(partial)
+            data_bytes = (
+                txt_file.read_text(encoding="utf-8") + "\n"
+            ).encode("utf-8")
+            remaining = TRAINING_LIMIT_BYTES - total
+            if remaining <= 0:
                 break
-            tmp.write(data)
-            total += len(encoded)
+            tmp.write(
+                data_bytes[:remaining].decode("utf-8", errors="ignore")
+            )
+            total += min(len(data_bytes), remaining)
     return Path(tmp.name)
 
 


### PR DESCRIPTION
## Summary
- Streamline `build_dataset` to respect a 20KB byte limit
- Expose `TRAINING_LIMIT_BYTES` for easy tuning

## Testing
- `ruff check molecule.py tests/test_build_dataset.py tests/test_respond_single_line.py tests/test_auto_training.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4dcacda148329b5ebe358a2ef3f4a