### PR TITLE
Ensure Memory connections are closed

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -12,6 +12,16 @@ class Memory:
         self.conn = sqlite3.connect(path)
         self._init_db()
 
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self.conn.close()
+
+    def __enter__(self) -> "Memory":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     def _init_db(self) -> None:
         cur = self.conn.cursor()
         cur.execute(
@@ -55,7 +65,7 @@ class Memory:
         self.save_conversation(question, answer)
 
     def update_repo_hash(self, repo_path: str | Path = ".") -> None:
-        """Compute SHA256 for every file and flag training if anything changed."""
+        """Compute file hashes and flag training when files change."""
         repo = Path(repo_path)
         changed = False
         db_path = Path(self.conn.execute("PRAGMA database_list").fetchone()[2])

--- a/molecule.py
+++ b/molecule.py
@@ -16,7 +16,7 @@ from telegram.ext import (
     filters,
 )
 
-from inhale_exhale import inhale, exhale
+from inhale_exhale import inhale, exhale, memory
 
 load_dotenv()
 
@@ -115,7 +115,9 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         else:
             if proc.returncode == 0:
                 lines = [
-                    line for line in stdout.decode().splitlines() if line.strip()
+                    line
+                    for line in stdout.decode().splitlines()
+                    if line.strip()
                 ]
                 reply = lines[-1] if lines else "No output from LE."
             else:
@@ -219,8 +221,11 @@ def main() -> None:
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, respond)
     )
-    warmup_model()
-    app.run_polling()
+    try:
+        warmup_model()
+        app.run_polling()
+    finally:
+        memory.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_training.py
+++ b/tests/test_auto_training.py
@@ -25,22 +25,24 @@ def test_update_repo_hash_detects_changes(tmp_path, caplog, monkeypatch):
     monkeypatch.setitem(sys.modules, "molecule", fake_mol)
 
     inhale_exhale = importlib.reload(importlib.import_module("inhale_exhale"))
-    mem = Memory(path=str(tmp_path / "mem.db"))
-    inhale_exhale.memory = mem
-    cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        file = Path("file.txt")
-        file.write_text("a")
-        mem.update_repo_hash()
-        mem.set_meta("needs_training", "0")
-        file.write_text("b")
-        with caplog.at_level(logging.INFO):
+    with Memory(path=str(tmp_path / "mem.db")) as mem:
+        inhale_exhale.memory = mem
+        cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            file = Path("file.txt")
+            file.write_text("a")
             mem.update_repo_hash()
-        assert mem.needs_training()
-        assert any("file.txt" in record.message for record in caplog.records)
-    finally:
-        os.chdir(cwd)
+            mem.set_meta("needs_training", "0")
+            file.write_text("b")
+            with caplog.at_level(logging.INFO):
+                mem.update_repo_hash()
+            assert mem.needs_training()
+            assert any(
+                "file.txt" in record.message for record in caplog.records
+            )
+        finally:
+            os.chdir(cwd)
 
 
 @pytest.mark.asyncio
@@ -56,15 +58,15 @@ async def test_exhale_triggers_training_when_needed(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "molecule", fake_mol)
 
     inhale_exhale = importlib.reload(importlib.import_module("inhale_exhale"))
-    mem = Memory(path=str(tmp_path / "mem.db"))
-    inhale_exhale.memory = mem
-    mem.set_meta("needs_training", "1")
+    with Memory(path=str(tmp_path / "mem.db")) as mem:
+        inhale_exhale.memory = mem
+        mem.set_meta("needs_training", "1")
 
-    await inhale_exhale.exhale(1, None)
-    assert fake_mol.TRAINING_TASK is not None
-    await fake_mol.TRAINING_TASK
-    assert event.is_set()
-    assert not mem.needs_training()
+        await inhale_exhale.exhale(1, None)
+        assert fake_mol.TRAINING_TASK is not None
+        await fake_mol.TRAINING_TASK
+        assert event.is_set()
+        assert not mem.needs_training()
 
 
 @pytest.mark.asyncio
@@ -82,9 +84,10 @@ async def test_startup_triggers_training_when_model_missing(
     monkeypatch.setitem(sys.modules, "molecule", fake_mol)
     monkeypatch.chdir(tmp_path)
 
-    importlib.reload(importlib.import_module("inhale_exhale"))
+    inhale_exhale = importlib.reload(importlib.import_module("inhale_exhale"))
 
     await asyncio.sleep(0)
     assert fake_mol.TRAINING_TASK is not None
     await fake_mol.TRAINING_TASK
     assert event.is_set()
+    inhale_exhale.memory.close()


### PR DESCRIPTION
## Summary
- add `Memory.close` and context manager helpers for connection cleanup
- close global `memory` when the Telegram bot stops
- adjust tests to close `Memory` instances after use

## Testing
- `flake8 memory.py molecule.py tests/test_auto_training.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e31329bc8329907f7843b8e1a839