### PR TITLE
Refine training triggering and repo hashing

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -34,12 +34,14 @@ def inhale(question: str, answer: str) -> None:
 
 
 async def exhale(chat_id: int, context) -> None:
-    """Trigger training in the background if needed."""
-    if memory.needs_training():
-        import molecule  # Local import to avoid circular dependency
-        if molecule.TRAINING_TASK is None or molecule.TRAINING_TASK.done():
-            logging.info("Starting background training")
-            molecule.TRAINING_TASK = asyncio.create_task(
-                molecule.run_training(chat_id, context)
-            )
-            memory.set_meta("needs_training", "0")
+    """Trigger training in the background if required."""
+    if not memory.needs_training():
+        return
+
+    import molecule  # Local import to avoid circular dependency
+
+    if molecule.TRAINING_TASK is None or molecule.TRAINING_TASK.done():
+        logging.info("Starting background training")
+        molecule.TRAINING_TASK = asyncio.create_task(
+            molecule.run_training(chat_id, context)
+        )

--- a/molecule.py
+++ b/molecule.py
@@ -151,35 +151,24 @@ async def run_training(
             stderr=asyncio.subprocess.PIPE,
         )
         try:
-            stdout, stderr = await asyncio.wait_for(
+            _, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=600
             )
         except asyncio.TimeoutError:
             proc.kill()
             await proc.communicate()
             logging.exception("Training timed out")
-            if context and chat_id is not None:
-                await context.bot.send_message(
-                    chat_id=chat_id, text="Training timed out."
-                )
             return
         if proc.returncode == 0:
+            memory.set_meta("needs_training", "0")
             if context and chat_id is not None:
                 await context.bot.send_message(
                     chat_id=chat_id, text="Training completed."
                 )
         else:
             logging.error("Training failed: %s", stderr.decode())
-            if context and chat_id is not None:
-                await context.bot.send_message(
-                    chat_id=chat_id, text="Training failed."
-                )
     except Exception:
         logging.exception("Training error")
-        if context and chat_id is not None:
-            await context.bot.send_message(
-                chat_id=chat_id, text="Training error."
-            )
     finally:
         dataset_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- ignore logs and other temporary artifacts when computing repository hash
- trigger background training only when retraining is required
- limit training failure notifications and clear training flag on success

## Testing
- `flake8 memory.py inhale_exhale.py molecule.py tests/test_auto_training.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9787e088329a671caa8cfc503f0