### PR TITLE
Include recent user messages when building dataset

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -64,6 +64,23 @@ class Memory:
         """Persist a conversation pair."""
         self.save_conversation(question, answer)
 
+    def get_messages(self, limit: int | None = None) -> list[str]:
+        """Return recent conversation lines in chronological order."""
+        cur = self.conn.cursor()
+        query = "SELECT question, answer FROM conversations ORDER BY id DESC"
+        if limit is not None:
+            cur.execute(query + " LIMIT ?", (limit,))
+        else:
+            cur.execute(query)
+        rows = cur.fetchall()
+        lines: list[str] = []
+        for question, answer in reversed(rows):
+            if question:
+                lines.append(question)
+            if answer:
+                lines.append(answer)
+        return lines
+
     def update_repo_hash(self, repo_path: str | Path = ".") -> None:
         """Compute file hashes and flag training when files change."""
         repo = Path(repo_path)

--- a/molecule.py
+++ b/molecule.py
@@ -73,7 +73,7 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not model_path.exists():
         if TRAINING_TASK is None or TRAINING_TASK.done():
             TRAINING_TASK = asyncio.create_task(run_training(None, None))
-        dataset_path = build_dataset()
+        dataset_path = build_dataset(question)
         try:
             data = dataset_path.read_text(encoding="utf-8").splitlines()
             lines = [line.strip() for line in data if line.strip()]
@@ -84,7 +84,7 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         inhale(question, reply)
         await exhale(update.effective_chat.id, context)
         return
-    dataset_path = build_dataset()
+    dataset_path = build_dataset(question)
     try:
         seed = random.randint(0, 2**31 - 1)
         proc = await asyncio.create_subprocess_exec(
@@ -194,7 +194,7 @@ async def train(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     TRAINING_TASK = asyncio.create_task(run_training(chat_id, context))
 
 
-def build_dataset() -> Path:
+def build_dataset(latest_line: str | None = None) -> Path:
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".txt", encoding="utf-8"
     ) as tmp:
@@ -210,6 +210,22 @@ def build_dataset() -> Path:
                 data_bytes[:remaining].decode("utf-8", errors="ignore")
             )
             total += min(len(data_bytes), remaining)
+        for line in memory.get_messages():
+            remaining = TRAINING_LIMIT_BYTES - total
+            if remaining <= 0:
+                break
+            data_bytes = (line + "\n").encode("utf-8")
+            tmp.write(
+                data_bytes[:remaining].decode("utf-8", errors="ignore")
+            )
+            total += min(len(data_bytes), remaining)
+        if latest_line:
+            remaining = TRAINING_LIMIT_BYTES - total
+            if remaining > 0:
+                data_bytes = (latest_line + "\n").encode("utf-8")
+                tmp.write(
+                    data_bytes[:remaining].decode("utf-8", errors="ignore")
+                )
     return Path(tmp.name)
 
 

--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -1,4 +1,5 @@
 import molecule
+from memory import Memory
 
 
 def test_build_dataset_enforces_limit(tmp_path, monkeypatch):
@@ -13,3 +14,22 @@ def test_build_dataset_enforces_limit(tmp_path, monkeypatch):
         assert dataset_path.stat().st_size == molecule.TRAINING_LIMIT_BYTES
     finally:
         dataset_path.unlink()
+
+
+def test_build_dataset_includes_memory_and_question(tmp_path, monkeypatch):
+    blood_dir = tmp_path / "blood"
+    blood_dir.mkdir()
+    (blood_dir / "base.txt").write_text("base\n")
+    mem = Memory(str(tmp_path / "memory.db"))
+    mem.record_message("q1", "a1")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(molecule, "memory", mem)
+    dataset_path = molecule.build_dataset("q2")
+    try:
+        lines = dataset_path.read_text(encoding="utf-8").splitlines()
+        assert lines[-1] == "q2"
+        assert "q1" in lines and "a1" in lines
+        assert "base" in lines
+    finally:
+        dataset_path.unlink()
+        mem.close()

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -24,7 +24,7 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
 
     dataset_file = tmp_path / "dataset.txt"
     dataset_file.write_text("hello\n")
-    monkeypatch.setattr(molecule, "build_dataset", lambda: dataset_file)
+    monkeypatch.setattr(molecule, "build_dataset", lambda q=None: dataset_file)
 
     monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
 
@@ -79,7 +79,7 @@ async def test_respond_handles_timeout(monkeypatch, tmp_path):
     molecule.WORK_DIR = names_dir
     dataset_file = tmp_path / "dataset.txt"
     dataset_file.write_text("hello\n")
-    monkeypatch.setattr(molecule, "build_dataset", lambda: dataset_file)
+    monkeypatch.setattr(molecule, "build_dataset", lambda q=None: dataset_file)
     monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
 
     async def dummy_exhale(chat_id, context):
@@ -131,7 +131,7 @@ async def test_respond_returns_line_when_model_missing(monkeypatch, tmp_path):
 
     dataset_file = tmp_path / "dataset.txt"
     dataset_file.write_text("line1\nline2\n")
-    monkeypatch.setattr(molecule, "build_dataset", lambda: dataset_file)
+    monkeypatch.setattr(molecule, "build_dataset", lambda q=None: dataset_file)
 
     started = {"flag": False}
 


### PR DESCRIPTION
## Summary
- Extend `build_dataset` to merge base text, memory conversations and the latest prompt
- Record and retrieve conversation lines from `Memory`
- Update tests for new dataset logic

## Testing
- `flake8 memory.py molecule.py tests/test_build_dataset.py tests/test_respond_single_line.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e998ca0483299af5f98522ce3cb2