### PR TITLE
Add configurable dataset directory via LE_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ charlotte
 ...
 ```
 
+By default these files are read from the `blood` directory. To use a different
+dataset location, set the `LE_DATA_DIR` environment variable to the directory
+containing your `.txt` files.
+
 To train a model and save it to the `names` directory:
 
 ```bash

--- a/molecule.py
+++ b/molecule.py
@@ -23,6 +23,7 @@ load_dotenv()
 TOKEN = os.getenv("TELEGRAM_TOKEN")
 WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
 SAMPLE_TIMEOUT = int(os.getenv("LE_SAMPLE_TIMEOUT", "120"))
+DATA_DIR = Path(os.getenv("LE_DATA_DIR", "blood"))
 TRAINING_TASK: asyncio.Task | None = None
 TRAINING_LIMIT_BYTES = 20 * 1024
 
@@ -195,11 +196,12 @@ async def train(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 def build_dataset() -> Path:
+    data_dir = Path(os.getenv("LE_DATA_DIR", str(DATA_DIR)))
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".txt", encoding="utf-8"
     ) as tmp:
         total = 0
-        for txt_file in Path("blood").glob("*.txt"):
+        for txt_file in data_dir.glob("*.txt"):
             data_bytes = (
                 txt_file.read_text(encoding="utf-8") + "\n"
             ).encode("utf-8")

--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -7,7 +7,7 @@ def test_build_dataset_enforces_limit(tmp_path, monkeypatch):
     chunk = "a" * (molecule.TRAINING_LIMIT_BYTES // 2)
     (blood_dir / "f1.txt").write_text(chunk)
     (blood_dir / "f2.txt").write_text(chunk)
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LE_DATA_DIR", str(blood_dir))
     dataset_path = molecule.build_dataset()
     try:
         assert dataset_path.stat().st_size == molecule.TRAINING_LIMIT_BYTES


### PR DESCRIPTION
## Summary
- allow dataset directory to be overridden via LE_DATA_DIR
- document LE_DATA_DIR usage
- adjust dataset builder test to set data dir through env var

## Testing
- `ruff check molecule.py tests/test_build_dataset.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e92ca7c883298c405b336a053de9