### PR TITLE
Add conversation context tracking

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -27,9 +27,9 @@ def _startup_training_check() -> None:
 asyncio.get_event_loop().call_soon(_startup_training_check)
 
 
-def inhale(question: str, answer: str) -> None:
-    """Record the latest conversation and update repository hash."""
-    memory.record_message(question, answer)
+def inhale(question: str, answer: str, context: str) -> None:
+    """Record the latest conversation along with its context and update the hash."""
+    memory.record_message(question, answer, context)
     memory.update_repo_hash()
 
 

--- a/le.py
+++ b/le.py
@@ -541,7 +541,8 @@ def chat(model, data_path, memory):
             out = out[:out.index(0)]
         response = train_dataset.decode(out)
         print(f'le: {response}')
-        memory.save_conversation(user, response)
+        combined_context = f"interactive:{user}"
+        memory.record_message(user, response, combined_context)
         with open(log_path, 'a', encoding='utf-8') as f:
             f.write(f'User: {user}\nLE: {response}\n')
 

--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -21,7 +21,7 @@ def test_build_dataset_includes_memory_and_question(tmp_path, monkeypatch):
     blood_dir.mkdir()
     (blood_dir / "base.txt").write_text("base\n")
     mem = Memory(str(tmp_path / "memory.db"))
-    mem.record_message("q1", "a1")
+    mem.record_message("q1", "a1", "ctx1")
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(molecule, "memory", mem)
     dataset_path = molecule.build_dataset("q2")

--- a/tests/test_memory_conversations.py
+++ b/tests/test_memory_conversations.py
@@ -1,0 +1,14 @@
+from memory import Memory
+
+
+def test_get_conversations_returns_context(tmp_path):
+    mem = Memory(str(tmp_path / "mem.db"))
+    try:
+        mem.record_message("q1", "a1", "ctx1")
+        mem.record_message("q2", "a2", "ctx2")
+        assert mem.get_conversations() == [
+            ("ctx1", "q1", "a1"),
+            ("ctx2", "q2", "a2"),
+        ]
+    finally:
+        mem.close()

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -26,7 +26,7 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
     dataset_file.write_text("hello\n")
     monkeypatch.setattr(molecule, "build_dataset", lambda q=None: dataset_file)
 
-    monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
+    monkeypatch.setattr(molecule, "inhale", lambda q, r, c: None)
 
     async def dummy_exhale(chat_id, context):
         return None
@@ -80,7 +80,7 @@ async def test_respond_handles_timeout(monkeypatch, tmp_path):
     dataset_file = tmp_path / "dataset.txt"
     dataset_file.write_text("hello\n")
     monkeypatch.setattr(molecule, "build_dataset", lambda q=None: dataset_file)
-    monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
+    monkeypatch.setattr(molecule, "inhale", lambda q, r, c: None)
 
     async def dummy_exhale(chat_id, context):
         return None
@@ -142,7 +142,7 @@ async def test_respond_returns_line_when_model_missing(monkeypatch, tmp_path):
     molecule.TRAINING_TASK = None
 
     monkeypatch.setattr(molecule.random, "choice", lambda seq: seq[0])
-    monkeypatch.setattr(molecule, "inhale", lambda q, r: None)
+    monkeypatch.setattr(molecule, "inhale", lambda q, r, c: None)
 
     async def dummy_exhale(chat_id, context):
         return None


### PR DESCRIPTION
## Summary
- track context with each recorded conversation
- compute dataset hash + prompt context before recording
- expose stored conversations for audit/debugging

## Testing
- `flake8 memory.py inhale_exhale.py molecule.py le.py tests/test_build_dataset.py tests/test_respond_single_line.py tests/test_memory_conversations.py` *(fails: E501 line too long, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef06acdc832988870d6f3a9d1d4e