### PR TITLE
feat: add prompt option for sampling

### DIFF
--- a/molecule.py
+++ b/molecule.py
@@ -84,7 +84,7 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         inhale(question, reply)
         await exhale(update.effective_chat.id, context)
         return
-    dataset_path = build_dataset(question)
+    dataset_path = build_dataset()
     try:
         seed = random.randint(0, 2**31 - 1)
         proc = await asyncio.create_subprocess_exec(
@@ -95,6 +95,8 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             "--work-dir",
             str(WORK_DIR),
             "--sample-only",
+            "--prompt",
+            question,
             "--num-samples",
             "1",
             "--seed",

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -65,6 +65,7 @@ async def test_respond_produces_one_line(monkeypatch, tmp_path):
 
     assert replies == ["sample"]
     assert "--num-samples" in captured["args"] and "1" in captured["args"]
+    assert "--prompt" in captured["args"] and "hi" in captured["args"]
     assert "--quiet" in captured["args"]
     assert "--work-dir" in captured["args"]
     assert str(names_dir) in captured["args"]


### PR DESCRIPTION
## Summary
- allow providing a `--prompt` in `le.py` sample-only mode
- pass Telegram messages via `--prompt` in `molecule.respond`
- test that response subprocess receives the prompt

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f24447d88329988d80003d03d993