### PR TITLE
Reduce training data limit to 10KB

### DIFF
--- a/molecule.py
+++ b/molecule.py
@@ -24,7 +24,7 @@ TOKEN = os.getenv("TELEGRAM_TOKEN")
 WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
 SAMPLE_TIMEOUT = int(os.getenv("LE_SAMPLE_TIMEOUT", "120"))
 TRAINING_TASK: asyncio.Task | None = None
-TRAINING_LIMIT_BYTES = 20 * 1024
+TRAINING_LIMIT_BYTES = 10 * 1024
 
 
 def warmup_model() -> None:


### PR DESCRIPTION
## Summary
- Lower training dataset limit from 20KB to 10KB so model training uses a smaller context.

## Testing
- `python -m pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a4f42647408329bd552fc06e6a5b7c