### PR TITLE
Log conversations to file with timestamps

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 
 from memory import Memory
@@ -30,6 +31,14 @@ asyncio.get_event_loop().call_soon(_startup_training_check)
 def inhale(question: str, answer: str) -> None:
     """Record the latest conversation and update repository hash."""
     memory.record_message(question, answer)
+
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+    timestamp = datetime.utcnow().isoformat()
+    log_file = log_dir / "conversations.txt"
+    with log_file.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\t{question}\t{answer}\n")
+
     memory.update_repo_hash()
 
 

--- a/tests/test_inhale_logging.py
+++ b/tests/test_inhale_logging.py
@@ -1,0 +1,19 @@
+import importlib
+from datetime import datetime
+from pathlib import Path
+
+from memory import Memory
+
+
+def test_inhale_writes_log(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inhale_exhale = importlib.reload(importlib.import_module("inhale_exhale"))
+    with Memory(path=str(tmp_path / "mem.db")) as mem:
+        inhale_exhale.memory = mem
+        inhale_exhale.inhale("question", "answer")
+        log_file = Path("logs") / "conversations.txt"
+        assert log_file.exists()
+        line = log_file.read_text(encoding="utf-8").strip()
+        parts = line.split("\t")
+        assert parts[1:] == ["question", "answer"]
+        datetime.fromisoformat(parts[0])


### PR DESCRIPTION
## Summary
- Log each question and reply with a timestamp to `logs/conversations.txt`
- Test that `inhale` creates a timestamped conversation log

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f78f581c8329b63a1e946aaf6520