### PR TITLE
Add fine-tuning scheduling and retraining triggers

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -54,3 +54,12 @@ async def exhale(chat_id: int, context) -> None:
         molecule.TRAINING_TASK = asyncio.create_task(
             molecule.run_training(chat_id, context)
         )
+    else:
+        logging.info("Training already running; will retrigger if still needed")
+
+        def _retry(_task: asyncio.Task) -> None:
+            asyncio.create_task(exhale(chat_id, context))
+
+        if not getattr(molecule.TRAINING_TASK, "_retry_set", False):
+            molecule.TRAINING_TASK.add_done_callback(_retry)
+            setattr(molecule.TRAINING_TASK, "_retry_set", True)

--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -6,7 +6,7 @@ import pytest
 import molecule
 
 
-async def _noop_run_training(chat_id, context):
+async def _noop_run_training(chat_id, context, extra_dataset=None):
     return None
 
 
@@ -136,7 +136,7 @@ async def test_respond_returns_line_when_model_missing(monkeypatch, tmp_path):
 
     started = {"flag": False}
 
-    async def dummy_run_training(chat_id, context):
+    async def dummy_run_training(chat_id, context, extra_dataset=None):
         started["flag"] = True
 
     molecule.run_training = dummy_run_training


### PR DESCRIPTION
## Summary
- Allow training to append an extra dataset and expose a `fine_tune` helper to launch it via `asyncio.create_task`
- Re-trigger background training whenever new data arrives during an existing run
- Test that successive >10KB dataset additions kick off training each time and update async test helpers

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a5051950ec8329b63ffc1df098b4a8