### PR TITLE
Add response logging and uniqueness checks

### DIFF
--- a/response_log.py
+++ b/response_log.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+from typing import Set
+
+LOG_PATH = os.getenv("RESPONSE_LOG_PATH")
+
+def _load_phrases() -> Set[str]:
+    if LOG_PATH and Path(LOG_PATH).exists():
+        with open(LOG_PATH, "r", encoding="utf-8") as f:
+            return {line.strip() for line in f if line.strip()}
+    return set()
+
+def is_unique(phrase: str) -> bool:
+    """Return True if ``phrase`` has not been logged yet."""
+    return phrase not in _load_phrases()
+
+def log_phrase(phrase: str) -> None:
+    """Append ``phrase`` to the log file if logging is enabled."""
+    if not LOG_PATH:
+        return
+    path = Path(LOG_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(phrase + "\n")
+
+def check_and_log(phrase: str) -> bool:
+    """Check uniqueness and log ``phrase`` if it is new.
+
+    Returns ``True`` when ``phrase`` was not seen before.
+    """
+    if is_unique(phrase):
+        log_phrase(phrase)
+        return True
+    return False


### PR DESCRIPTION
## Summary
- add `response_log` utility to track generated phrases via `RESPONSE_LOG_PATH`
- use `response_log` in `sample_prompt` to avoid sending duplicate responses

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a518395b7083299b8ca0a5efa664c0