### PR TITLE
feat: train in background and sample with temperature

### DIFF
--- a/le.py
+++ b/le.py
@@ -547,7 +547,14 @@ def print_samples(num=20, return_samples=False):
     X_init = torch.zeros(num, 1, dtype=torch.long).to(DEVICE)
     top_k = args.top_k if args.top_k != -1 else None
     steps = train_dataset.get_output_length() - 1  # -1 because we already start with <START> token (index 0)
-    X_samp = generate(model, X_init, steps, top_k=top_k, do_sample=True).to('cpu')
+    X_samp = generate(
+        model,
+        X_init,
+        steps,
+        temperature=args.temperature,
+        top_k=top_k,
+        do_sample=True,
+    ).to('cpu')
     train_samples, test_samples, new_samples = [], [], []
     samples = []
     for i in range(X_samp.size(0)):
@@ -741,6 +748,7 @@ if __name__ == '__main__':
     # sampling
     parser.add_argument('--num-samples', type=int, default=1, help="number of samples to draw when using --sample-only")
     parser.add_argument('--top-k', type=int, default=-1, help="top-k for sampling, -1 means no top-k")
+    parser.add_argument('--temperature', type=float, default=1.0, help="temperature for sampling")
     parser.add_argument('--prompt', type=str, default=None, help="prompt to condition on when sampling")
     # model
     parser.add_argument('--type', type=str, default='transformer', help="model class type to use, bigram|mlp|rnn|gru|bow|transformer")
@@ -810,6 +818,7 @@ if __name__ == '__main__':
                 model,
                 x,
                 train_dataset.get_output_length(),
+                temperature=args.temperature,
                 do_sample=True,
                 top_k=top_k,
             ).to('cpu')

--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -76,6 +76,28 @@ def test_build_dataset_reads_various_file_types(tmp_path, monkeypatch):
         mem.close()
 
 
+def test_build_dataset_reads_nested_files(tmp_path, monkeypatch):
+    blood_dir = tmp_path / "blood"
+    blood_dir.mkdir()
+    (blood_dir / "b.txt").write_text("blood text")
+
+    nested_dir = tmp_path / "datasets" / "sub"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "n.txt").write_text("nested")
+
+    importlib.reload(tg)
+    mem = memory.Memory(str(tmp_path / "memory.db"))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(tg, "memory", mem)
+    dataset_path = tg.build_dataset()
+    try:
+        lines = dataset_path.read_text(encoding="utf-8").splitlines()
+        assert "nested" in lines
+    finally:
+        dataset_path.unlink()
+        mem.close()
+
+
 def test_update_repo_hash_respects_env_limit(tmp_path, monkeypatch):
     limit = 100
     monkeypatch.setenv("LE_TRAINING_LIMIT_BYTES", str(limit))


### PR DESCRIPTION
## Summary
- Trigger background training when no model is present and notify that the model is training
- Sample exclusively from the trained model using configurable top-k and temperature
- Include nested dataset files when building the training corpus

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51a96ce348329927ccc1d0183aedc