### PR TITLE
feat: log response diversity metrics

### DIFF
--- a/le.py
+++ b/le.py
@@ -564,6 +564,7 @@ def print_samples(num=20, return_samples=False):
         crop_index = row.index(0) if 0 in row else len(row)
         row = row[:crop_index]
         word_samp = train_dataset.decode(row)
+        metrics.log_response_metrics(word_samp, i)
         samples.append(word_samp)
         # separately track samples that we have and have not seen before
         if train_dataset.contains(word_samp):
@@ -627,6 +628,7 @@ def chat(model, data_path, memory):
             out = out[:out.index(0)]
         response = train_dataset.decode(out)
         print(f'le: {response}')
+        metrics.log_response_metrics(response, res_step)
         memory.save_conversation(user, response)
         resonance = metrics.compute_resonance(model, train_dataset, user, response)
         metrics.log_resonance(resonance, res_step)

--- a/tests/test_metrics_logging.py
+++ b/tests/test_metrics_logging.py
@@ -1,5 +1,6 @@
 import math
 import torch.nn as nn
+import pytest
 
 import metrics
 from le import CharDataset
@@ -28,3 +29,22 @@ def test_resonance_logging():
     metrics.log_resonance(res, 0)
     assert metrics.get_metric("Resonance") == res
     assert -1.0 <= res <= 1.0
+
+
+def test_unique_token_ratio():
+    metrics.reset_metrics()
+    metrics.log_unique_token_ratio("a a b", 0)
+    assert metrics.get_metric("UniqueTokenRatio") == pytest.approx(2 / 3)
+
+
+def test_avg_response_length():
+    metrics.reset_metrics()
+    metrics.log_avg_response_length("a b", 0)
+    metrics.log_avg_response_length("c d e", 1)
+    assert metrics.get_metric("AvgResponseLength") == pytest.approx(2.5)
+
+
+def test_ngram_repeat_rate():
+    metrics.reset_metrics()
+    metrics.log_ngram_repeat_rate("a b a b", 0, n=2)
+    assert metrics.get_metric("RepeatRate") == pytest.approx(1 / 3)


### PR DESCRIPTION
## Summary
- add metrics for unique token ratio, average response length, and n-gram repeat rate
- log response statistics during training and chat sessions
- test logging of new response metrics

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51fced93c8329846c3d1c524598d5