### PR TITLE
Echo question while training

### DIFF
--- a/tests/test_respond_single_line.py
+++ b/tests/test_respond_single_line.py
@@ -160,7 +160,7 @@ async def test_respond_reports_training_when_model_missing(monkeypatch, tmp_path
     )
 
     await tg.respond(update, None)
-    assert replies == ["модель обучается…"]
+    assert replies == ["hi"]
     assert tg.TRAINING_TASK is not None
     await tg.TRAINING_TASK
     assert started["flag"]

--- a/tg.py
+++ b/tg.py
@@ -88,7 +88,7 @@ async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not model_path.exists():
         if TRAINING_TASK is None or TRAINING_TASK.done():
             TRAINING_TASK = asyncio.create_task(run_training(None, None))
-        reply = "модель обучается…"
+        reply = question
         await update.message.reply_text(reply)
         inhale(question, reply)
         await exhale(update.effective_chat.id, context)


### PR DESCRIPTION
## Summary
- Return the user's original message when the model is missing, starting training asynchronously in the background.
- Update tests to reflect new behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a522ada2cc8329b7b633cb774076dc