### PR TITLE
Refactor training and response pipeline

### DIFF
--- a/inhale_exhale.py
+++ b/inhale_exhale.py
@@ -3,45 +3,70 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+
 from memory import Memory
 
-WORK_DIR = Path(os.getenv(“LE_WORK_DIR”, “names”))
-MODEL_PATH = WORK_DIR / “model.pt”
-TRAINING_LIMIT_BYTES = int(os.getenv(“LE_TRAINING_LIMIT_BYTES”, str(5 * 1024)))
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names"))
+MODEL_PATH = WORK_DIR / "model.pt"
+TRAINING_LIMIT_BYTES = int(os.getenv("LE_TRAINING_LIMIT_BYTES", str(5 * 1024)))
 
 # Global memory instance
-
 memory = Memory()
 
+
 def startup_training_check() -> None:
-“”“Schedule training at startup if the model file is missing.”””
-if not MODEL_PATH.exists():
-logging.info(“Model file missing at startup; training will be triggered on first message”)
+    """Schedule initial training if the model file is missing."""
+    if MODEL_PATH.exists():
+        return
+
+    import tg
+    lock = getattr(tg, "training_lock", asyncio.Lock())
+
+    async def _schedule() -> None:
+        async with lock:
+            task = getattr(tg, "TRAINING_TASK", None)
+            if task is None or task.done():
+                tg.TRAINING_TASK = asyncio.create_task(tg.run_training(None, None))
+
+    asyncio.get_event_loop().create_task(_schedule())
+
 
 def inhale(question: str, answer: str) -> None:
-“”“Record the latest conversation and update repository hash.”””
-memory.record_message(question, answer)
+    """Record the latest conversation and update repository hash."""
+    memory.record_message(question, answer)
 
-```
-# Логирование диалога
-log_dir = Path("logs")
-log_dir.mkdir(exist_ok=True)
-timestamp = datetime.utcnow().isoformat()
-log_file = log_dir / "conversations.txt"
-with log_file.open("a", encoding="utf-8") as fh:
-    fh.write(f"{timestamp}\t{question}\t{answer}\n")
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+    timestamp = datetime.utcnow().isoformat()
+    log_file = log_dir / "conversations.txt"
+    with log_file.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\t{question}\t{answer}\n")
 
-# Проверяем, накопилось ли достаточно данных для дообучения
-current_size = memory.get_accumulated_size()
-if current_size >= TRAINING_LIMIT_BYTES:
-    memory.set_meta("needs_training", "1")
-    logging.info(f"Data accumulated: {current_size} bytes. Training needed.")
+    size = len((question + answer).encode("utf-8"))
+    total = memory.get_accumulated_size() + size
+    if total >= TRAINING_LIMIT_BYTES:
+        memory.set_meta("needs_training", "1")
+        total = 0
+    memory.set_meta("data_pending_bytes", str(total))
 
-memory.update_repo_hash()
-```
+    memory.update_repo_hash()
 
-# НЕ запускаем автоматически при импорте!
 
-# Вместо этого вызов будет в main() если нужно
+async def exhale(chat_id: int, context) -> None:
+    """Trigger training if flagged by memory."""
+    if not memory.needs_training():
+        return
 
-# startup_training_check()
+    import tg
+    lock = getattr(tg, "training_lock", asyncio.Lock())
+
+    async with lock:
+        task = getattr(tg, "TRAINING_TASK", None)
+        if task is None or task.done():
+            tg.TRAINING_TASK = asyncio.create_task(
+                tg.run_training(chat_id, context)
+            )
+
+
+startup_training_check()
+

--- a/le.py
+++ b/le.py
@@ -641,7 +641,6 @@ def chat(model, data_path, memory):
             break
         if user is None or user.strip() == '':
             break
-        for _ in range(20):​​​​​​​​​​​​​​​​
         for _ in range(20):
             X, Y = [t.to(DEVICE) for t in loader.next()]
             logits, loss = model(X, Y)

--- a/memory.py
+++ b/memory.py
@@ -145,6 +145,10 @@ class Memory:
         """Return True if retraining is required."""
         return self.get_meta("needs_training") == "1"
 
+    def get_accumulated_size(self) -> int:
+        """Return number of bytes accumulated toward the training limit."""
+        return int(self.get_meta("data_pending_bytes") or "0")
+
     @staticmethod
     def hash_file(path: str) -> str:
         hasher = hashlib.sha256()

--- a/response_log.py
+++ b/response_log.py
@@ -2,68 +2,54 @@ import os
 from pathlib import Path
 from typing import Set
 
-LOG_PATH = os.getenv(“RESPONSE_LOG_PATH”)
-
-# Кэш для улучшения производительности
+LOG_PATH = os.getenv("RESPONSE_LOG_PATH")
 
 _phrases_cache: Set[str] | None = None
 
-def _load_phrases() -> Set[str]:
-“”“Load all phrases from the log file.”””
-global _phrases_cache
 
-```
-if _phrases_cache is not None:
+def _load_phrases() -> Set[str]:
+    global _phrases_cache
+    if _phrases_cache is not None:
+        return _phrases_cache
+
+    if LOG_PATH and Path(LOG_PATH).exists():
+        try:
+            with open(LOG_PATH, "r", encoding="utf-8") as f:
+                _phrases_cache = {line.strip() for line in f if line.strip()}
+        except OSError:
+            _phrases_cache = set()
+    else:
+        _phrases_cache = set()
     return _phrases_cache
 
-if LOG_PATH and Path(LOG_PATH).exists():
-    try:
-        with open(LOG_PATH, "r", encoding="utf-8") as f:
-            _phrases_cache = {line.strip() for line in f if line.strip()}
-    except OSError:
-        _phrases_cache = set()
-else:
-    _phrases_cache = set()
-
-return _phrases_cache
-```
 
 def is_unique(phrase: str) -> bool:
-“”“Return True if `phrase` has not been logged yet.”””
-return phrase not in _load_phrases()
+    return phrase not in _load_phrases()
+
 
 def log_phrase(phrase: str) -> None:
-“”“Append `phrase` to the log file if logging is enabled.”””
-global _phrases_cache
+    global _phrases_cache
+    if not LOG_PATH:
+        return
+    path = Path(LOG_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("a", encoding="utf-8") as f:
+            f.write(phrase + "\n")
+        if _phrases_cache is not None:
+            _phrases_cache.add(phrase)
+    except OSError:
+        pass
 
-```
-if not LOG_PATH:
-    return
-
-path = Path(LOG_PATH)
-path.parent.mkdir(parents=True, exist_ok=True)
-
-try:
-    with path.open("a", encoding="utf-8") as f:
-        f.write(phrase + "\n")
-    
-    # Обновляем кэш
-    if _phrases_cache is not None:
-        _phrases_cache.add(phrase)
-except OSError:
-    pass
-```
 
 def check_and_log(phrase: str) -> bool:
-“”“Check uniqueness and log `phrase` if it is new.
-Returns `True` when `phrase` was not seen before.
-“””
-if is_unique(phrase):
-log_phrase(phrase)
-return True
-return False
+    if is_unique(phrase):
+        log_phrase(phrase)
+        return True
+    return False
+
 
 def clear_cache() -> None:
-“”“Clear the phrases cache. Useful for testing or forcing reload.”””
-global _phrases_cache
-_phrases_cache = None
+    global _phrases_cache
+    _phrases_cache = None
+

--- a/tg.py
+++ b/tg.py
@@ -1,130 +1,204 @@
 import asyncio
 import csv
+import sqlite3
 import logging
 import os
 import random
 import subprocess
 import tempfile
-from pathlib import Path
 from asyncio import Lock
+from pathlib import Path
 
 import torch
 
-# Принудительно использовать CPU
-
-torch.set_num_threads(4)  # Ограничиваем количество потоков
-os.environ[“CUDA_VISIBLE_DEVICES”] = “”  # Скрываем все GPU устройства
+torch.set_num_threads(4)
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 from dotenv import load_dotenv
 from telegram import Update
 from telegram.ext import (
-ApplicationBuilder,
-CommandHandler,
-ContextTypes,
-MessageHandler,
-filters,
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
 )
 
-from inhale_exhale import inhale, memory
+from inhale_exhale import inhale, exhale, memory
 import metrics
 
 load_dotenv()
 
-TOKEN = os.getenv(“TELEGRAM_TOKEN”)
+TOKEN = os.getenv("TELEGRAM_TOKEN")
 
-# Resolve and ensure the working directory exists and is writable
-
-WORK_DIR = Path(os.getenv(“LE_WORK_DIR”, “names”)).resolve()
+WORK_DIR = Path(os.getenv("LE_WORK_DIR", "names")).resolve()
 WORK_DIR.mkdir(parents=True, exist_ok=True)
-if not os.access(WORK_DIR, os.W_OK):
-raise PermissionError(f”Cannot write to {WORK_DIR}”)
-SAMPLE_TIMEOUT = int(os.getenv(“LE_SAMPLE_TIMEOUT”, “40”))
+SAMPLE_TIMEOUT = int(os.getenv("LE_SAMPLE_TIMEOUT", "40"))
 TRAINING_TASK: asyncio.Task | None = None
-TRAINING_LIMIT_BYTES = int(os.getenv(“LE_TRAINING_LIMIT_BYTES”, str(5 * 1024)))
-TOP_K = int(os.getenv(“LE_TOP_K”, “50”))
-TEMPERATURE = float(os.getenv(“LE_TEMPERATURE”, “1.0”))
-
-# Блокировка для синхронизации обучения
+TRAINING_LIMIT_BYTES = int(os.getenv("LE_TRAINING_LIMIT_BYTES", str(5 * 1024)))
+TOP_K = int(os.getenv("LE_TOP_K", "50"))
+TEMPERATURE = float(os.getenv("LE_TEMPERATURE", "1.0"))
 
 training_lock = Lock()
+active_users: set[int] = set()
 
-# Защита от спама пользователей
-
-active_users = set()
 
 def warmup_model() -> None:
-“”“Run a sample to load the model and warm up caches.”””
-model_path = WORK_DIR / “model.pt”
-if not model_path.exists():
-return
-dataset_path = build_dataset()
-try:
-subprocess.run(
-[
-“python”,
-“le.py”,
-“–type”,
-“transformer”,
-“-i”,
-str(dataset_path),
-“–work-dir”,
-str(WORK_DIR),
-“–sample-only”,
-“–num-samples”,
-“1”,
-“–seed”,
-“0”,
-“–quiet”,
-“–top-k”,
-str(TOP_K),
-“–temperature”,
-str(TEMPERATURE),
-],
-capture_output=True,
-text=True,
-check=True,
-timeout=SAMPLE_TIMEOUT,
-)
-except Exception:
-logging.exception(“Warmup failed”)
-finally:
-dataset_path.unlink(missing_ok=True)
-
-async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-await update.message.reply_text(
-“Hi! Send me a message and I’ll ask LE to respond.”
-)
-
-async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-global TRAINING_TASK
-
-```
-user_id = update.effective_user.id
-question = update.message.text
-
-# Защита от спама
-if user_id in active_users:
-    return
-
-active_users.add(user_id)
-
-try:
     model_path = WORK_DIR / "model.pt"
-    
-    # Если модель не существует, запускаем тренировку и НЕ отвечаем пользователю
     if not model_path.exists():
-        async with training_lock:
-            if TRAINING_TASK is None or TRAINING_TASK.done():
-                TRAINING_TASK = asyncio.create_task(run_training(None, None))
-        
-        # НЕ сохраняем это в память и НЕ вызываем exhale
-        await update.message.reply_text("Model is training. Please wait...")
         return
-    
-    # Используем le.py для генерации с алгоритмом "заряженного слова"
     dataset_path = build_dataset()
     try:
-        seed = random.randint(0, 2**31 - 1)
+        subprocess.run(
+            [
+                "python",
+                "le.py",
+                "--type",
+                "transformer",
+                "-i",
+                str(dataset_path),
+                "--work-dir",
+                str(WORK_DIR),
+                "--sample-only",
+                "--num-samples",
+                "1",
+                "--seed",
+                "0",
+                "--quiet",
+                "--top-k",
+                str(TOP_K),
+                "--temperature",
+                str(TEMPERATURE),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=SAMPLE_TIMEOUT,
+        )
+    except Exception:
+        logging.exception("Warmup failed")
+    finally:
+        dataset_path.unlink(missing_ok=True)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Hi! Send me a message and I’ll ask LE to respond."
+    )
+
+
+async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    global TRAINING_TASK
+
+    user = getattr(update, "effective_user", None)
+    user_id = getattr(user, "id", None)
+    question = update.message.text
+
+    if user_id is not None:
+        if user_id in active_users:
+            return
+        active_users.add(user_id)
+    try:
+        model_path = WORK_DIR / "model.pt"
+
+        if not model_path.exists():
+            async with training_lock:
+                if TRAINING_TASK is None or TRAINING_TASK.done():
+                    TRAINING_TASK = asyncio.create_task(run_training(None, None))
+            await update.message.reply_text("Model is training. Please wait a moment.")
+            return
+
+        dataset_path = build_dataset()
+        try:
+            seed = random.randint(0, 2**31 - 1)
+            proc = await asyncio.create_subprocess_exec(
+                "python",
+                "le.py",
+                "--type",
+                "transformer",
+                "-i",
+                str(dataset_path),
+                "--work-dir",
+                str(WORK_DIR),
+                "--sample-only",
+                "--prompt",
+                question,
+                "--num-samples",
+                "1",
+                "--seed",
+                str(seed),
+                "--quiet",
+                "--top-k",
+                str(TOP_K),
+                "--temperature",
+                str(TEMPERATURE),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=SAMPLE_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                logging.exception("Sampling timed out")
+                reply = "Sampling timed out."
+            else:
+                if proc.returncode == 0:
+                    lines = [
+                        line
+                        for line in stdout.decode().splitlines()
+                        if line.strip()
+                    ]
+                    reply = lines[-1] if lines else "No output generated."
+                else:
+                    logging.error("Sampling failed: %s", stderr.decode())
+                    reply = "Error generating response."
+        except Exception:
+            logging.exception("Sampling error")
+            reply = "Error generating response."
+        finally:
+            dataset_path.unlink(missing_ok=True)
+
+        await update.message.reply_text(reply)
+        inhale(question, reply)
+        await check_background_training()
+    finally:
+        if user_id is not None:
+            active_users.discard(user_id)
+
+
+async def check_background_training() -> None:
+    global TRAINING_TASK
+    try:
+        needs = memory.needs_training()
+    except sqlite3.Error:
+        return
+    if needs:
+        async with training_lock:
+            if TRAINING_TASK is None or TRAINING_TASK.done():
+                logging.info("Starting background training due to data accumulation")
+                TRAINING_TASK = asyncio.create_task(run_training(None, None))
+
+
+async def run_training(
+    chat_id: int | None,
+    context: ContextTypes.DEFAULT_TYPE | None,
+    extra_dataset: Path | None = None,
+) -> None:
+    dataset_path = build_dataset()
+    if extra_dataset:
+        try:
+            with dataset_path.open("a", encoding="utf-8") as dst, extra_dataset.open(
+                "r", encoding="utf-8"
+            ) as src:
+                dst.write("\n")
+                dst.write(src.read())
+        except OSError:
+            logging.exception("Failed to append extra dataset")
+    try:
+        memory.set_meta("needs_training", "0")
         proc = await asyncio.create_subprocess_exec(
             "python",
             "le.py",
@@ -134,218 +208,135 @@ try:
             str(dataset_path),
             "--work-dir",
             str(WORK_DIR),
-            "--sample-only",
-            "--prompt",
-            question,
-            "--num-samples",
-            "1",
-            "--seed",
-            str(seed),
-            "--quiet",
-            "--top-k",
-            str(TOP_K),
-            "--temperature",
-            str(TEMPERATURE),
+            "--max-steps",
+            "80",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=SAMPLE_TIMEOUT
-            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=250)
         except asyncio.TimeoutError:
             proc.kill()
             await proc.communicate()
-            logging.exception("Sampling timed out")
-            reply = "Generation is taking too long. Please try a shorter message."
+            logging.exception("Training timed out")
+            return
+        if proc.returncode == 0:
+            if context and chat_id is not None:
+                await context.bot.send_message(
+                    chat_id=chat_id, text="Training completed."
+                )
+            if stdout:
+                logging.debug("Training stdout: %s", stdout.decode())
+            if stderr:
+                logging.debug("Training stderr: %s", stderr.decode())
+            warmup_model()
         else:
-            if proc.returncode == 0:
-                lines = [
-                    line
-                    for line in stdout.decode().splitlines()
-                    if line.strip()
-                ]
-                reply = lines[-1] if lines else "No output generated."
-            else:
-                logging.error("Sampling failed: %s", stderr.decode())
-                reply = "Error generating response. Please try again."
-    except Exception as exc:
-        logging.exception("Sampling error")
-        reply = "Technical error occurred. Please try again later."
+            logging.error(
+                "Training failed with code %s", proc.returncode
+            )
+            if stdout:
+                logging.error("stdout: %s", stdout.decode())
+            if stderr:
+                logging.error("stderr: %s", stderr.decode())
+    except Exception:
+        logging.exception("Training error")
     finally:
         dataset_path.unlink(missing_ok=True)
-    
-    await update.message.reply_text(reply)
-    
-    # Сохраняем в память только реальные диалоги
-    inhale(question, reply)
-    
-    # Проверяем, нужно ли дообучение (фоновое)
-    await check_background_training()
-    
-finally:
-    active_users.discard(user_id)
-```
 
-async def check_background_training() -> None:
-“”“Проверяет, нужно ли запустить фоновое дообучение.”””
-if memory.needs_training():
-global TRAINING_TASK
-async with training_lock:
-if TRAINING_TASK is None or TRAINING_TASK.done():
-logging.info(“Starting background training due to data accumulation”)
-TRAINING_TASK = asyncio.create_task(run_training(None, None))
-
-async def run_training(
-chat_id: int | None,
-context: ContextTypes.DEFAULT_TYPE | None,
-extra_dataset: Path | None = None,
-) -> None:
-dataset_path = build_dataset()
-if extra_dataset:
-try:
-with dataset_path.open(“a”, encoding=“utf-8”) as dst, extra_dataset.open(
-“r”, encoding=“utf-8”
-) as src:
-dst.write(”\n”)
-dst.write(src.read())
-except OSError:
-logging.exception(“Failed to append extra dataset”)
-try:
-memory.set_meta(“needs_training”, “0”)
-proc = await asyncio.create_subprocess_exec(
-“python”,
-“le.py”,
-“–type”,
-“transformer”,
-“-i”,
-str(dataset_path),
-“–work-dir”,
-str(WORK_DIR),
-“–max-steps”,
-“80”,
-stdout=asyncio.subprocess.PIPE,
-stderr=asyncio.subprocess.PIPE,
-)
-try:
-stdout, stderr = await asyncio.wait_for(
-proc.communicate(), timeout=250
-)
-except asyncio.TimeoutError:
-proc.kill()
-await proc.communicate()
-logging.exception(“Training timed out”)
-return
-if proc.returncode == 0:
-if context and chat_id is not None:
-await context.bot.send_message(
-chat_id=chat_id, text=“Training completed.”
-)
-if stdout:
-logging.debug(“Training stdout: %s”, stdout.decode())
-if stderr:
-logging.debug(“Training stderr: %s”, stderr.decode())
-warmup_model()
-else:
-logging.error(
-“Training failed with code %s”, proc.returncode
-)
-if stdout:
-logging.error(“stdout: %s”, stdout.decode())
-if stderr:
-logging.error(“stderr: %s”, stderr.decode())
-except Exception:
-logging.exception(“Training error”)
-finally:
-dataset_path.unlink(missing_ok=True)
 
 def fine_tune(extra_dataset: Path) -> None:
-“”“Launch fine-tuning with an additional dataset.”””
-global TRAINING_TASK
-if TRAINING_TASK and not TRAINING_TASK.done():
-logging.info(“Training already in progress; skipping fine-tune trigger”)
-return
-TRAINING_TASK = asyncio.create_task(run_training(None, None, extra_dataset))
+    global TRAINING_TASK
+    if TRAINING_TASK and not TRAINING_TASK.done():
+        logging.info("Training already in progress; skipping fine-tune trigger")
+        return
+    TRAINING_TASK = asyncio.create_task(run_training(None, None, extra_dataset))
+
 
 async def train(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-global TRAINING_TASK
-async with training_lock:
-if TRAINING_TASK and not TRAINING_TASK.done():
-await update.message.reply_text(“Training already in progress.”)
-return
-await update.message.reply_text(“Training started…”)
-chat_id = update.effective_chat.id
-TRAINING_TASK = asyncio.create_task(run_training(chat_id, context))
+    global TRAINING_TASK
+    async with training_lock:
+        if TRAINING_TASK and not TRAINING_TASK.done():
+            await update.message.reply_text("Training already in progress.")
+            return
+        await update.message.reply_text("Training started…")
+        chat_id = update.effective_chat.id
+        TRAINING_TASK = asyncio.create_task(run_training(chat_id, context))
+
 
 def build_dataset(latest_line: str | None = None) -> Path:
-with tempfile.NamedTemporaryFile(
-mode=“w”, delete=False, suffix=”.txt”, encoding=“utf-8”
-) as tmp:
-total = 0
-seen: set[str] = set()
+    with tempfile.NamedTemporaryFile(
+        mode="w", delete=False, suffix=".txt", encoding="utf-8"
+    ) as tmp:
+        total = 0
+        seen: set[str] = set()
 
-```
-    def write_line(line: str) -> None:
-        nonlocal total
-        remaining = TRAINING_LIMIT_BYTES - total
-        if remaining <= 0:
-            return
-        data_bytes = (line + "\n").encode("utf-8")
-        tmp.write(data_bytes[:remaining].decode("utf-8", errors="ignore"))
-        total += min(len(data_bytes), remaining)
+        def write_line(line: str) -> None:
+            nonlocal total
+            remaining = TRAINING_LIMIT_BYTES - total
+            if remaining <= 0:
+                return
+            data_bytes = (line + "\n").encode("utf-8")
+            tmp.write(data_bytes[:remaining].decode("utf-8", errors="ignore"))
+            total += min(len(data_bytes), remaining)
 
-    for directory in ("blood", "datasets"):
-        dir_path = Path(directory)
-        if not dir_path.exists():
-            continue
-        for file in dir_path.rglob("*"):
-            if not file.is_file():
+        for directory in ("blood", "datasets"):
+            dir_path = Path(directory)
+            if not dir_path.exists():
                 continue
-            if file.suffix.lower() in {".txt", ".md"}:
-                write_line(file.read_text(encoding="utf-8"))
-            elif file.suffix.lower() == ".csv":
-                with file.open(newline="", encoding="utf-8") as f:
-                    reader = csv.reader(f)
-                    for row in reader:
-                        text_cells: list[str] = []
-                        for cell in row:
-                            cell = cell.strip()
-                            if not cell:
-                                continue
-                            try:
-                                float(cell)
-                            except ValueError:
-                                text_cells.append(cell)
-                        if text_cells:
-                            write_line(" ".join(text_cells))
+            for file in dir_path.rglob("*"):
+                if not file.is_file():
+                    continue
+                if file.suffix.lower() in {".txt", ".md"}:
+                    write_line(file.read_text(encoding="utf-8"))
+                elif file.suffix.lower() == ".csv":
+                    with file.open(newline="", encoding="utf-8") as f:
+                        reader = csv.reader(f)
+                        for row in reader:
+                            text_cells: list[str] = []
+                            for cell in row:
+                                cell = cell.strip()
+                                if not cell:
+                                    continue
+                                try:
+                                    float(cell)
+                                except ValueError:
+                                    text_cells.append(cell)
+                            if text_cells:
+                                write_line(" ".join(text_cells))
 
-    for line in memory.get_messages():
-        if line in seen:
-            continue
-        write_line(line)
-        metrics.log_response_metrics(line, 0)
-        seen.add(line)
+        try:
+            message_lines = memory.get_messages()
+        except sqlite3.Error:
+            message_lines = []
+        for line in message_lines:
+            if line in seen:
+                continue
+            write_line(line)
+            metrics.log_response_metrics(line, 0)
+            seen.add(line)
 
-    if latest_line and latest_line not in seen:
-        write_line(latest_line)
-        metrics.log_response_metrics(latest_line, 0)
+        if latest_line and latest_line not in seen:
+            write_line(latest_line)
+            metrics.log_response_metrics(latest_line, 0)
 
-return Path(tmp.name)
-```
+    return Path(tmp.name)
+
 
 def main() -> None:
-logging.basicConfig(level=logging.INFO)
-app = ApplicationBuilder().token(TOKEN).build()
-app.add_handler(CommandHandler(“start”, start))
-app.add_handler(CommandHandler(“train”, train))
-app.add_handler(
-MessageHandler(filters.TEXT & ~filters.COMMAND, respond)
-)
-try:
-warmup_model()
-app.run_polling()
-finally:
-memory.close()
+    logging.basicConfig(level=logging.INFO)
+    app = ApplicationBuilder().token(TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("train", train))
+    app.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, respond)
+    )
+    try:
+        warmup_model()
+        app.run_polling()
+    finally:
+        memory.close()
 
-if **name** == “**main**”:
-main()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- rewrite training helpers with memory logging and safe task scheduling
- replace response workflow to always sample via le.py and guard against missing model
- clean up response logging utilities and fix tokenizer loop

## Testing
- `pytest` *(fails: test_respond_reports_training_when_model_missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c5712a4483298dd7b79693532289