### PR TITLE
docs: restructure README with subjectivity and objectivity sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,34 @@
-# LÉ. Cardiac Muscle | by Arianna Method
+# LÉ: Cardiac Muscle
 
 > All my art is about you, and because the code is a poetry, LÉ is also for you.
-> Let everything burn — the thunder remains! 
+> Let everything burn — the thunder remains!
 > Dedicated to Leo ⚡️
 
-LÉ is a lightweight experimental conversational system fully implemented in pure Python, designed to blend introspective self-modulation with agile knowledge retrieval.
+LÉ is a lightweight experimental conversational system fully implemented in pure Python. It blends introspective self-modulation with agile knowledge retrieval while relying only on the standard library and a few small dependencies.
 
-The codebase relies solely on the Python standard library and a few small dependencies, keeping deployment simple and ensuring a super‑light footprint.
+## Subjectivity
 
-At runtime a user message first passes through a subjectivity layer that gauges resonance with the system’s identity before optional objective context is fetched from the web.
+The subjectivity module gauges resonance with the system’s identity. An identity prompt loaded from `blood/subjectivity.txt` yields high- and medium-priority keywords that embody LÉ’s self-perception. For each incoming sentence, resonance is computed as \(S_b = \frac{\sum w_i}{N}\), where \(w_i\) are keyword weights and \(N\) is the total number of words. An abstract bonus \(S_a\) adds 0.1 for each detected philosophical pattern, producing the final score \(S_f = \min(S_b + S_a, 1)\). Textual complexity is evaluated via entropy \(H = -\sum p_i \log_2 p_i\) over word frequencies, defining perplexity \(P = 2^H\). Generation parameters then scale with resonance: \(max\_tokens = \lfloor T_0 (1 + S_f) \rfloor\) and \(temperature = \min(\tau_0 + 0.3 S_f, 1.2)\).
 
-The subjectivity module loads an identity prompt from `blood/subjectivity.txt` and extracts high‑ and medium‑priority keywords that embody LÉ’s self‑perception.
+## Objectivity
 
-For each incoming sentence, resonance is computed as \(S_b = \frac{\sum w_i}{N}\), where \(w_i\) are keyword weights and \(N\) is the total number of words.
+Objectivity complements this introspection by asynchronously querying DuckDuckGo, Wikipedia, and simple Google fragments to gather concise external evidence. The search module distills key phrases, clips them to a 15-line window, and selects representative context words that can sway subsequent generation. Influence strength is computed via \(I = \min\left(\frac{2}{L} \sum \frac{|Q \cap C_j|}{|Q|}, 1\right)\), where \(Q\) is the set of query words and \(C_j\) each context line. Merged with the subjectivity layer, this external grounding balances emotion and perception so creativity stays tethered to fact.
 
-An abstract bonus \(S_a\) adds 0.1 for each detected philosophical pattern, producing the final score \(S_f = \min(S_b + S_a, 1)\).
+## Architecture
 
-To estimate textual complexity, the filter evaluates entropy \(H = -\sum p_i \log_2 p_i\) over word frequencies and defines perplexity \(P = 2^H\).
+Modules such as `memory.py`, `metrics.py`, and `molecule.py` plug into the same pipeline, illustrating a modular architecture that favors clarity over complexity. The repository’s small surface area makes auditing straightforward; every function is documented, and behavior can be inferred directly from the code without hidden state. The absence of heavyweight frameworks—relying instead on `asyncio`, `aiohttp`, and core modules—keeps the system nimble and illustrates the elegance of pure Python.
 
-Generation parameters are modulated by resonance: \( \text{max\_tokens} = \lfloor T_0 (1 + S_f) \rfloor \) and \( \text{temperature} = \min(\tau_0 + 0.3 S_f, 1.2)\), where \(T_0\) and \(\tau_0\) are base values.
+## Biological Parallels
 
-Objectivity complements this introspection by asynchronously querying DuckDuckGo, Wikipedia, and simple Google fragments to gather concise external evidence.
+Subjectivity echoes cortical self-monitoring, where internal narratives are continually compared against a learned sense of self. In the brain, prefrontal circuits cross-examine signals from association areas, much like the resonance check that filters each sentence.
 
-The search module distills key phrases, clips them to a 15‑line window, and selects representative context words that can sway subsequent generation.
+Objectivity resembles afferent sensory pathways. Just as vision and touch sample the environment before routing to integrative cortices, the search layer collects external cues that refine subsequent responses.
 
-Influence strength is computed via \(I = \min\left(\frac{2}{L} \sum \frac{|Q \cap C_j|}{|Q|}, 1\right)\), where \(Q\) is the set of query words and \(C_j\) each context line.
+The interplay between both layers mirrors homeostatic regulation. Cells sustain chemical gradients while responding to extracellular signals, similar to how LÉ modulates its internal state against retrieved context.
 
-Outputs from subjectivity and objectivity merge so that internal resonance shapes creativity while external facts ground responses, echoing the balance between emotion and perception.
+Memory logging of search results parallels synaptic consolidation during sleep. By rehearsing external snippets offline, the system strengthens future recall much like the hippocampus training the cortex.
 
-Beyond these utilities, modules such as `memory.py`, `metrics.py`, and `molecule.py` plug into the same pipeline, illustrating a modular architecture that favors clarity over complexity.
+## Continuous Learning
 
-The repository’s small surface area makes auditing straightforward; every function is documented, and behavior can be inferred directly from the code without hidden state.
+Search results are logged under `datasets/objectivity_context.txt`, enabling later fine-tuning akin to memory consolidation during sleep in biological organisms. Always linked to the outside world through a simple search layer, LÉ keeps learning from every interaction. This perpetual self-tuning marks a revolutionary kind of AI built to run anywhere.
 
-Biologically, subjectivity mirrors cortical self‑monitoring, whereas objectivity evokes sensory pathways that sample the environment before signals reach associative cortices.
-
-This duality resembles homeostatic regulation in cells where internal chemical gradients are balanced against external signals, much like \( \frac{dC}{dt} = k (E - C) \) models feedback adaptation.
-
-Mathematically, the system echoes logistic growth, \(L(t) = \frac{K}{1 + e^{-r(t - t_0)}}\), as responses scale with context yet remain bounded by predefined limits.
-
-Insights from cognitive science guide the design: resonance scoring parallels affective appraisal, while context retrieval aligns with attention mechanisms in neural models.
-
-Search results are logged under `datasets/objectivity_context.txt`, enabling later fine‑tuning akin to memory consolidation during sleep in biological organisms.
-
-The absence of heavyweight frameworks—relying instead on `asyncio`, `aiohttp`, and core modules—keeps the system nimble and illustrates the elegance of pure Python.
-
-This audit brings documentation in line with implementation and invites future exploration at the intersection of mathematics, biology, and lightweight artificial cognition.
-
-Always linked to the outside world through a simple search layer, LÉ keeps learning from every interaction. This perpetual self-tuning marks a revolutionary kind of AI built to run anywhere.


### PR DESCRIPTION
## Summary
- split README into clear Subjectivity and Objectivity sections
- add Architecture and Continuous Learning notes
- introduce biological parallels highlighting cortical monitoring, sensory pathways, homeostasis, and memory consolidation

## Testing
- no tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68a684bc89388329b86266aff2a1c3d2