### PR TITLE
Remove lightning emoji from core modules

### DIFF
--- a/le.py
+++ b/le.py
@@ -702,13 +702,13 @@ def sample_prompt(prompt: str, model, dataset, memory: Memory, *, max_new_tokens
         # Добавляем префиксы утилит в начало
         prefixes = []
         if resonance_prefix:
-            prefixes.append(resonance_prefix)  # ⚡ для subjectivity
+            prefixes.append(resonance_prefix)  # для subjectivity
         if objectivity_prefix:
             prefixes.append(objectivity_prefix)  # 🌐 для objectivity
         if pain_prefix:
             prefixes.append(pain_prefix)  # 😰😟😕 для pain
         if chaos_prefix:
-            prefixes.append(chaos_prefix)  # 🔮🌀⚡ для sixthsense (усиленное болью!)
+            prefixes.append(chaos_prefix)  # 🔮🌀 для sixthsense (усиленное болью!)
         
         if prefixes:
             prefix_str = "".join(prefixes)

--- a/sixthsense.py
+++ b/sixthsense.py
@@ -156,7 +156,7 @@ class SixthSense:
             temp_boost = (self.chaos - 0.7) * 0.8  # До +0.24 температуры
             
         elif self.chaos > 0.4:
-            prefix = "⚡"  # Средний хаос - спайк энергии
+            prefix = ""  # Средний хаос - спайк энергии
             multiplier = 1.0 + (self.chaos - 0.4) * 0.8  # До 1.24x токенов
             temp_boost = (self.chaos - 0.4) * 0.4  # До +0.12 температуры
             


### PR DESCRIPTION
## Summary
- Remove lightning emoji from sixthsense chaos prefix
- Strip lightning icon references from utility prefix comments

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75c1a82248329a4371ac42aaf844c